### PR TITLE
Fix typos in Kafka spec

### DIFF
--- a/src/main/resources/api-specification/kafka-spec.yaml
+++ b/src/main/resources/api-specification/kafka-spec.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.1
 x-stoplight:
   id: 123456789
 info:
-  title: Connetor service
+  title: Connector service
   description: This API provides all operations with messages
   version: 1.0.0
   contact:
@@ -13,7 +13,7 @@ servers:
     description: Generated server url
 tags:
   - name: genericDlq
-    description: messages realted with generic dlq
+    description: messages related with generic dlq
 components:
   securitySchemes:
     bearerAuth:


### PR DESCRIPTION
## Summary
- correct typos in the OpenAPI specification

## Testing
- `mvn -q -e -DskipTests=false clean verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867d8727598832ab67696335a651eaa