### PR TITLE
Update bean example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ public class MyErrorMapper implements KafkaErrorMapper<MyDlqMessage> {
 3. Provide it to the error handler:
 ```java
 @Bean
-public KafkaErrorHandler<MyDlqMessage> errorHandler(KafkaGenericPublisher<MyDlqMessage> publisher) {
-    return new KafkaErrorHandler<>(publisher, errorProps, new MyErrorMapper());
+public KafkaErrorHandler<MyDlqMessage> errorHandler(
+        KafkaGenericPublisher<MyDlqMessage> publisher,
+        BindingServiceProperties bindingProps) {
+    KafkaRetryHeaderUtils retryUtils = new KafkaRetryHeaderUtils(bindingProps);
+    return new KafkaErrorHandler<>(publisher, new MyErrorMapper(), retryUtils);
 }
 ```
 


### PR DESCRIPTION
## Summary
- adjust README bean example to use `KafkaRetryHeaderUtils` and the latest `KafkaErrorHandler` constructor

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867d8710158832a89ef4bc7eaa5fc5f