### PR TITLE
Add KafkaHeaderUtils test

### DIFF
--- a/src/test/unit/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/util/KafkaHeaderUtilsTest.java
+++ b/src/test/unit/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/util/KafkaHeaderUtilsTest.java
@@ -1,0 +1,27 @@
+package com.bnpparibas.bp2s.combo.comboservices.library.kafka.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bnpparibas.bp2s.combo.comboservices.library.kafka.headers.KafkaHeaderKeys;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+class KafkaHeaderUtilsTest {
+
+    @Test
+    void getObjectMsgIdReturnsValueWhenHeaderPresent() {
+        Message<String> message = MessageBuilder.withPayload("payload")
+                .setHeader(KafkaHeaderKeys.MESSAGE_ID.getKey(), "123")
+                .build();
+
+        assertThat(KafkaHeaderUtils.getObjectMsgId(message)).contains(123L);
+    }
+
+    @Test
+    void getObjectMsgIdReturnsEmptyWhenHeaderMissing() {
+        Message<String> message = MessageBuilder.withPayload("payload").build();
+
+        assertThat(KafkaHeaderUtils.getObjectMsgId(message)).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test for `KafkaHeaderUtils#getObjectMsgId`

## Testing
- `mvn test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6867d86e8788832aa1ba4eabb90a7bc2