### PR TITLE
Fix long header parsing

### DIFF
--- a/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/util/KafkaHeaderUtils.java
+++ b/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/util/KafkaHeaderUtils.java
@@ -47,6 +47,6 @@ public final class KafkaHeaderUtils {
 
     public static Optional<Long> getHeaderAsLong(MessageHeaders headers, String key) {
         Object value = headers.get(key);
-        return value != null ? Optional.of(Long.getLong(value.toString())) : Optional.empty();
+        return value != null ? Optional.of(Long.parseLong(value.toString())) : Optional.empty();
     }
 }


### PR DESCRIPTION
## Summary
- use `Long.parseLong` in KafkaHeaderUtils#getHeaderAsLong

## Testing
- `mvn test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_6867d85af22c832abe17a8cd7707cdbf