### PR TITLE
Fix error mapper and header utils

### DIFF
--- a/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/KafkaCoreAutoConfiguration.java
+++ b/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/KafkaCoreAutoConfiguration.java
@@ -6,6 +6,7 @@ import com.bnpparibas.bp2s.combo.comboservices.library.kafka.core.KafkaGenericPu
 import com.bnpparibas.bp2s.combo.comboservices.library.kafka.error.KafkaErrorHandler;
 import com.bnpparibas.bp2s.combo.comboservices.library.kafka.error.KafkaErrorMapper;
 import com.bnpparibas.bp2s.combo.comboservices.library.kafka.model.KafkaPublishableMessage;
+import com.bnpparibas.bp2s.combo.comboservices.library.kafka.model.DefaultKafkaDlqMessage;
 import com.bnpparibas.bp2s.combo.comboservices.library.kafka.util.KafkaRetryHeaderUtils;
 import java.time.OffsetDateTime;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -32,8 +33,8 @@ public class KafkaCoreAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public KafkaErrorMapper<KafkaPublishableMessage> defaultKafkaErrorMapper() {
-        return (message, exception) -> KafkaPublishableMessage.builder()
-                .originalMessage(message.getPayload().toString())
+        return (message, exception) -> DefaultKafkaDlqMessage.builder()
+                .message(message.getPayload().toString())
                 .headers(message.getHeaders())
                 .messageType((String) KafkaErrorMetadataContext.get(KafkaHeaderKeys.MESSAGE_TYPE.getKey()).orElse("UNKNOWN"))
                 .status((String) KafkaErrorMetadataContext.get(KafkaHeaderKeys.STATUS.getKey()).orElse("FAILED"))

--- a/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/model/DefaultKafkaDlqMessage.java
+++ b/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/model/DefaultKafkaDlqMessage.java
@@ -1,0 +1,23 @@
+package com.bnpparibas.bp2s.combo.comboservices.library.kafka.model;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Default implementation of {@link KafkaPublishableMessage} used for error handling.
+ */
+@Getter
+@Builder
+public class DefaultKafkaDlqMessage implements KafkaPublishableMessage {
+    private final String topicName;
+    private final Object message;
+    private final Map<String, Object> headers;
+    private final String messageType;
+    private final Object payload;
+    private final String status;
+    private final OffsetDateTime createdAt;
+    private final String errorMsg;
+    private final Long objectMsgId;
+}

--- a/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/util/KafkaHeaderUtils.java
+++ b/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/util/KafkaHeaderUtils.java
@@ -47,6 +47,6 @@ public final class KafkaHeaderUtils {
 
     public static Optional<Long> getHeaderAsLong(MessageHeaders headers, String key) {
         Object value = headers.get(key);
-        return value != null ? Optional.of(Long.getLong(value.toString())) : Optional.empty();
+        return value != null ? Optional.of(Long.parseLong(value.toString())) : Optional.empty();
     }
 }


### PR DESCRIPTION
## Summary
- add DefaultKafkaDlqMessage implementation
- fix defaultKafkaErrorMapper to use DefaultKafkaDlqMessage
- fix header parsing bug using `Long.parseLong`

## Testing
- `./mvnw -q clean verify` *(fails: Failed to fetch ... apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_6867d662b3dc832a8375162b1487c0d5