### PR TITLE
Fix AssertJ import by adding dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,19 +84,27 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- Mockito -->
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<version>${mockito-core.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-junit-jupiter</artifactId>
-			<version>${mockito-core.version}</version>
-			<scope>test</scope>
-		</dependency>
+                <!-- Mockito -->
+                <dependency>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-core</artifactId>
+                        <version>${mockito-core.version}</version>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-junit-jupiter</artifactId>
+                        <version>${mockito-core.version}</version>
+                        <scope>test</scope>
+                </dependency>
+
+                <!-- AssertJ for fluent assertions -->
+                <dependency>
+                        <groupId>org.assertj</groupId>
+                        <artifactId>assertj-core</artifactId>
+                        <version>${assertj-core.version}</version>
+                        <scope>test</scope>
+                </dependency>
 
 		<!-- Cucumber -->
 		<dependency>


### PR DESCRIPTION
## Summary
- include `assertj-core` as a test dependency so `org.assertj` imports resolve

## Testing
- `mvnw -q test` *(fails: Failed to fetch Apache Maven - internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6867db11b8e8832a82c57feb0d2fb796