### PR TITLE
Enable OpenAPI generation for message models

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
 							<goal>generate</goal>
 						</goals>
 						<configuration>
-							<inputSpec>${project.basedir}/src/main/resources/api-specification/models/kafka-messages/global-dlq.yaml</inputSpec>
+                                                        <inputSpec>${project.basedir}/src/main/resources/api-specification/kafka-spec.yaml</inputSpec>
 							<generatorName>java</generatorName>
 							<library>spring-boot</library>
 							<output>${project.build.directory}/generated-sources/openapi</output>
@@ -252,7 +252,7 @@
 								<interfaceOnly>true</interfaceOnly>
 								<useBeanValidation>true</useBeanValidation>
 								<serializableModel>true</serializableModel>
-								<modelNameSuffix></modelNameSuffix>
+                                                                <modelNameSuffix>Message</modelNameSuffix>
 							</configOptions>
 							<skipOverwrite>false</skipOverwrite>
 							<generateApis>false</generateApis>


### PR DESCRIPTION
## Summary
- adjust the OpenAPI generator configuration to use the main Kafka spec
- append `Message` suffix to generated model classes

## Testing
- `./mvnw clean verify` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_6867dca51d40832aba91d2f3f2da2097