### PR TITLE
Add documentation and Javadoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ public KafkaErrorHandler<MyDlqMessage> errorHandler(
 }
 ```
 
+### Additional Configuration
+
+Disable the binder's built-in DLQ so this library can manage retries:
+
+```yaml
+spring:
+  cloud:
+    stream:
+      kafka:
+        bindings:
+          <your-consumer>:
+            consumer:
+              enable-dlq: false
+```
+
 ## ❗ What NOT to Configure in application.yaml
 
 Avoid the following `spring.cloud.stream` Kafka configurations to prevent conflicts with this library's retry and DLQ mechanisms:
@@ -52,4 +67,5 @@ spring.cloud.stream.kafka.binder.*
 - Lets you customize error handling via pluggable `KafkaErrorMapper<T>`
 - Keeps Kafka concerns modular and reusable
 - Prepares your app for future Kafka extensions
+- Stores custom metadata in a thread local context accessible during error mapping
 

--- a/docs/architecture.adoc
+++ b/docs/architecture.adoc
@@ -1,0 +1,46 @@
+= Library Architecture
+:toc: left
+:sectnums:
+
+This document describes the inner workings of the Kafka core library.
+
+== Message Flow
+
+The following UML sequence illustrates how the main components interact when a message fails processing:
+
+[plantuml]
+----
+@startuml
+actor Consumer
+participant "KafkaErrorHandler" as Handler
+participant "KafkaRetryHeaderUtils" as RetryUtil
+participant "KafkaErrorMapper" as Mapper
+participant "KafkaGenericPublisher" as Publisher
+Consumer -> Handler : handleError(msg, ex, dlq)
+Handler -> RetryUtil : incrementAndGetRetryAttempt(msg)
+Handler -> RetryUtil : resolveMaxAttemptsFromMessage(msg)
+alt attempts < max
+    Handler -> Consumer : throw KafkaProcessingException
+else
+    Handler -> Mapper : buildErrorMessage(msg, ex)
+    Handler -> Publisher : publish(errorMsg, dlq)
+end
+@enduml
+----
+
+== Metadata Context Usage
+
+The library stores user provided metadata in a thread local map so it can be retrieved later by the error mapper.
+
+[plantuml]
+----
+@startuml
+actor "User Code"
+participant "KafkaErrorMetadataContext" as Ctx
+"User Code" -> Ctx : put(key,value)
+"User Code" -> Handler : handleError(msg, ex, dlq)
+Handler -> Mapper : buildErrorMessage(msg, ex)
+Mapper -> Ctx : get(key)
+@enduml
+----
+

--- a/docs/integration.adoc
+++ b/docs/integration.adoc
@@ -68,6 +68,14 @@ public KafkaErrorHandler<MyDlqMessage> errorHandler(KafkaGenericPublisher<MyDlqM
 - Error handling is completely **customizable per project**.
 - Library remains **fully reusable and clean** with no tight coupling.
 
+== Important Configuration
+
+Disable the binder's DLQ so retries are handled exclusively by this library:
+
+```yaml
+spring.cloud.stream.kafka.bindings.<consumer>.consumer.enable-dlq: false
+```
+
 == Summary
 
 - The library **does not dictate** your DLQ message structure.

--- a/docs/usage-guide.adoc
+++ b/docs/usage-guide.adoc
@@ -1,0 +1,60 @@
+= Usage Guide
+:toc: left
+:sectnums:
+
+This guide shows how to integrate and configure the library.
+
+== Dependency
+
+Add the Maven dependency:
+
+```xml
+<dependency>
+  <groupId>com.bnpparibas.bp2s.combo.comboservices.library</groupId>
+  <artifactId>kafka-core-library</artifactId>
+  <version>1.0.0</version>
+</dependency>
+```
+
+== Configuration
+
+Disable the binder DLQ and configure your consumer:
+
+```yaml
+spring:
+  cloud:
+    stream:
+      kafka:
+        bindings:
+          auditConsumer-in-0:
+            consumer:
+              enable-dlq: false
+      bindings:
+        auditConsumer-in-0:
+          consumer:
+            max-attempts: 3
+```
+
+== Error Mapper
+
+Implement `KafkaErrorMapper<T>` if you need a custom DLQ payload:
+
+```java
+@Bean
+public KafkaErrorHandler<MyDlqMessage> errorHandler(
+        KafkaGenericPublisher<MyDlqMessage> publisher,
+        BindingServiceProperties props) {
+    KafkaRetryHeaderUtils utils = new KafkaRetryHeaderUtils(props);
+    KafkaErrorMapper<MyDlqMessage> mapper = (msg, ex) ->
+            MyDlqMessage.builder()
+                .messageType("audit")
+                .status("failed")
+                .payload(msg.getPayload())
+                .errorMsg(ex.getMessage())
+                .build();
+    return new KafkaErrorHandler<>(publisher, mapper, utils);
+}
+```
+
+Values placed in `KafkaErrorMetadataContext` via `KafkaHeaderUtils.setHeaderAsObject(...)` are available when building the error message.
+

--- a/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/KafkaCoreAutoConfiguration.java
+++ b/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/KafkaCoreAutoConfiguration.java
@@ -19,19 +19,39 @@ import org.springframework.context.annotation.Configuration;
 
 //@formatter:off
 /**
- * Autoconfiguration for Kafka core components including DLQ handling.
+ * Spring Boot auto-configuration that registers the core Kafka beans used by
+ * this library. It exposes a {@link KafkaGenericPublisher} for publishing
+ * messages, a default {@link KafkaErrorMapper} that builds a
+ * {@link DefaultKafkaDlqMessage}, and a {@link KafkaErrorHandler} preconfigured
+ * with {@link KafkaRetryHeaderUtils}.
  */
 @Configuration
 @ConditionalOnMissingBean(BindingServiceProperties.class)
 public class KafkaCoreAutoConfiguration {
 
+    /**
+     * Name of the output binding used by the library to publish DLQ messages.
+     */
     public static final String GLOBAL_DLQ_OUT = "global-dlq-out-0";
 
+    /**
+     * Creates the generic publisher used by the error handler to send messages
+     * to Kafka topics.
+     *
+     * @param streamBridge Spring Cloud Stream bridge used for publishing
+     * @return configured publisher
+     */
     @Bean
     public KafkaGenericPublisher<GenericKafkaMessage> kafkaGenericPublisher(StreamBridge streamBridge) {
         return new KafkaGenericPublisher<>(streamBridge);
     }
 
+    /**
+     * Provides a default {@link KafkaErrorMapper} that converts failed messages
+     * to {@link DefaultKafkaDlqMessage} instances.
+     *
+     * @return default mapper used when no custom mapper is defined
+     */
     @Bean
     @ConditionalOnMissingBean
     public KafkaErrorMapper<GenericKafkaMessage> defaultKafkaErrorMapper() {
@@ -48,6 +68,16 @@ public class KafkaCoreAutoConfiguration {
                 .build();
     }
 
+    /**
+     * Configures the {@link KafkaErrorHandler} used by consumers to handle
+     * failures. The handler delegates to the given mapper and publisher and
+     * applies retry logic based on the provided binding properties.
+     *
+     * @param publisher the publisher used to send DLQ messages
+     * @param errorMapper mapper converting failed messages
+     * @param bindingServiceProperties Spring Cloud binding properties
+     * @return a fully configured error handler
+     */
     @Bean
     @ConditionalOnMissingBean
     public KafkaErrorHandler<GenericKafkaMessage> kafkaErrorHandler(KafkaGenericPublisher<GenericKafkaMessage> publisher, KafkaErrorMapper<GenericKafkaMessage> errorMapper, BindingServiceProperties bindingServiceProperties) {

--- a/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/context/KafkaErrorMetadataContext.java
+++ b/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/context/KafkaErrorMetadataContext.java
@@ -6,25 +6,48 @@ import java.util.Optional;
 import lombok.NoArgsConstructor;
 
 /**
- * Thread local context to allow
+ * Utility storing metadata related to a Kafka message in a thread-local map.
+ * Developers can add arbitrary key/value pairs that will be available to the
+ * {@link com.bnpparibas.bp2s.combo.comboservices.library.kafka.error.KafkaErrorMapper}
+ * when building the DLQ message.
  */
 @NoArgsConstructor
 public class KafkaErrorMetadataContext {
 
     private static final ThreadLocal<Map<String, Object>> CONTEXT = ThreadLocal.withInitial(HashMap::new);
 
+    /**
+     * Store a value in the current thread context.
+     *
+     * @param key context key
+     * @param value value to store
+     */
     public static void put(String key, Object value) {
         CONTEXT.get().put(key, value);
     }
 
+    /**
+     * Retrieve a value from the context.
+     *
+     * @param key context key
+     * @return optional value, empty if not present
+     */
     public static Optional<Object> get(String key) {
         return Optional.ofNullable(CONTEXT.get().get(key));
     }
 
+    /**
+     * Clears the context for the current thread.
+     */
     public static void clear() {
         CONTEXT.remove();
     }
 
+    /**
+     * Obtain a copy of all stored values.
+     *
+     * @return map containing the context values
+     */
     public static Map<String, Object> getAll() {
         return new HashMap<>(CONTEXT.get());
     }

--- a/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/core/KafkaGenericPublisher.java
+++ b/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/core/KafkaGenericPublisher.java
@@ -12,14 +12,33 @@ import org.springframework.util.MimeTypeUtils;
 
 @Slf4j
 @Component
+/**
+ * Publishes {@link GenericKafkaMessage} objects to Kafka using Spring Cloud
+ * Stream's {@link StreamBridge}.
+ *
+ * @param <T> type of message being sent
+ */
 public class KafkaGenericPublisher<T extends GenericKafkaMessage> {
 
+    /** Spring's bridge used to send messages to Kafka. */
     private final StreamBridge streamBridge;
 
+    /**
+     * Constructs a new publisher using the provided {@link StreamBridge}.
+     *
+     * @param streamBridge bridge used to send messages
+     */
     public KafkaGenericPublisher(StreamBridge streamBridge) {
         this.streamBridge = streamBridge;
     }
 
+    /**
+     * Publishes the given payload to the specified binding name.
+     * Headers are automatically set with JSON content type.
+     *
+     * @param payload           message to send
+     * @param topicBindingName  output binding configured in Spring Cloud Stream
+     */
     public void publish(T payload, String topicBindingName) {
         Message<T> dlqMessage = MessageBuilder
                 .withPayload(payload)
@@ -29,6 +48,14 @@ public class KafkaGenericPublisher<T extends GenericKafkaMessage> {
         streamBridge.send(topicBindingName, dlqMessage);
     }
 
+    /**
+     * Publishes using a raw topic name and optional headers. This method allows
+     * forwarding a message to a specific Kafka topic.
+     *
+     * @param topic   the Kafka topic
+     * @param payload payload to send
+     * @param headers additional headers to attach; may be {@code null}
+     */
     public void publish(String topic, T payload, MessageHeaders headers) {
         MessageBuilder<T> builder = MessageBuilder
                 .withPayload(payload)

--- a/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/error/KafkaErrorHandler.java
+++ b/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/error/KafkaErrorHandler.java
@@ -7,18 +7,45 @@ import com.bnpparibas.bp2s.combo.comboservices.library.kafka.util.KafkaRetryHead
 import io.micrometer.common.util.StringUtils;
 import org.springframework.messaging.Message;
 
+/**
+ * Central component responsible for processing consumer failures. It keeps
+ * track of retry attempts via {@link KafkaRetryHeaderUtils} and publishes
+ * messages to a DLQ once the maximum number of attempts is exceeded.
+ *
+ * @param <T> type of message handled by the publisher
+ */
 public class KafkaErrorHandler<T extends GenericKafkaMessage> {
 
+    /** Publisher used to send messages to the DLQ. */
     private final KafkaGenericPublisher<T> publisher;
+    /** Application specific mapper used to convert messages. */
     private final KafkaErrorMapper<T> mapper;
+    /** Utility handling retry headers and configuration. */
     private final KafkaRetryHeaderUtils kafkaRetryHeaderUtils;
 
+    /**
+     * Creates a new error handler.
+     *
+     * @param publisher publisher responsible for sending DLQ messages
+     * @param mapper mapper converting failed messages
+     * @param kafkaRetryHeaderUtils helper for retry header management
+     */
     public KafkaErrorHandler(KafkaGenericPublisher<T> publisher, KafkaErrorMapper<T> mapper, KafkaRetryHeaderUtils kafkaRetryHeaderUtils) {
         this.publisher = publisher;
         this.mapper = mapper;
         this.kafkaRetryHeaderUtils = kafkaRetryHeaderUtils;
     }
 
+    /**
+     * Processes a failed message. If the retry attempts have not been
+     * exhausted, a {@link KafkaProcessingException} is thrown to trigger a
+     * retry. Otherwise the message is converted using the mapper and published
+     * to the configured DLQ.
+     *
+     * @param message     the original message
+     * @param exception   the exception thrown by the consumer
+     * @param dlqTopicName name of the DLQ topic
+     */
     public void handleError(Message<T> message, Exception exception, String dlqTopicName) {
         int currentAttempt = kafkaRetryHeaderUtils.incrementAndGetRetryAttempt(message);
 

--- a/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/exception/KafkaProcessingException.java
+++ b/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/exception/KafkaProcessingException.java
@@ -1,10 +1,26 @@
 package com.bnpparibas.bp2s.combo.comboservices.library.kafka.exception;
 
+/**
+ * Exception thrown by {@link com.bnpparibas.bp2s.combo.comboservices.library.kafka.error.KafkaErrorHandler}
+ * to signal that a message should be retried or that DLQ publication failed.
+ */
 public class KafkaProcessingException extends RuntimeException {
+
+    /**
+     * Creates a new exception with a message only.
+     *
+     * @param message description of the failure
+     */
     public KafkaProcessingException(String message) {
         super(message);
     }
 
+    /**
+     * Creates a new exception with a message and root cause.
+     *
+     * @param message description of the failure
+     * @param cause   underlying cause
+     */
     public KafkaProcessingException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/model/DefaultKafkaDlqMessage.java
+++ b/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/model/DefaultKafkaDlqMessage.java
@@ -6,6 +6,12 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @SuperBuilder
+/**
+ * Basic DLQ message implementation used by the default error mapper. It extends
+ * {@link GenericKafkaMessage} and adds an {@code errorMsg} field describing the
+ * failure cause.
+ */
 public class DefaultKafkaDlqMessage extends GenericKafkaMessage {
+    /** Description of the processing error. */
     private final String errorMsg;
 }

--- a/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/util/KafkaHeaderUtils.java
+++ b/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/util/KafkaHeaderUtils.java
@@ -14,51 +14,115 @@ public final class KafkaHeaderUtils {
 
     private KafkaHeaderUtils() {}
 
+    /**
+     * Stores the message type both in the message headers and in the
+     * {@link KafkaErrorMetadataContext}.
+     *
+     * @param message     message being processed
+     * @param messageType logical type of the message
+     */
     public static void setMessageType(Message<?> message, String messageType) {
         setHeaderAsObject(message, KafkaHeaderKeys.MESSAGE_TYPE.getKey(), messageType);
     }
 
+    /**
+     * Stores the processing status in the message headers and context.
+     *
+     * @param message     message being processed
+     * @param statusValue custom status value
+     */
     public static void setStatus(Message<?> message, String statusValue) {
         setHeaderAsObject(message, KafkaHeaderKeys.STATUS.getKey(), statusValue);
     }
 
+    /**
+     * Records the original topic name from which the message was received.
+     *
+     * @param message message being processed
+     * @param topic   topic name
+     */
     public static void setOriginalTopic(Message<?> message, String topic) {
         setHeaderAsObject(message, KafkaHeaderKeys.ORIGINAL_TOPIC.getKey(), topic);
     }
 
+    /**
+     * Generic helper to set a header value and mirror it in the context.
+     *
+     * @param message message to modify
+     * @param key     header key
+     * @param value   value to set
+     */
     public static void setHeaderAsObject(Message<?> message, String key, Object value) {
         MessageHeaderAccessor accessor = MessageHeaderAccessor.getMutableAccessor(message);
         accessor.setHeader(key, value);
         KafkaErrorMetadataContext.put(key, value);
     }
 
+    /**
+     * Retrieves the message type from the headers or the context.
+     *
+     * @param message source message
+     * @return optional message type
+     */
     public static Optional<String> getMessageType(Message<?> message) {
         return getHeaderAsString(message.getHeaders(), KafkaHeaderKeys.MESSAGE_TYPE.getKey())
                 .or(() -> KafkaErrorMetadataContext.get(KafkaHeaderKeys.MESSAGE_TYPE.getKey())
                         .map(Object::toString));
     }
 
+    /**
+     * Retrieves the processing status from the headers or context.
+     *
+     * @param message message to read from
+     * @return optional status
+     */
     public static Optional<String> getStatus(Message<?> message) {
         return getHeaderAsString(message.getHeaders(), KafkaHeaderKeys.STATUS.getKey())
                 .or(() -> KafkaErrorMetadataContext.get(KafkaHeaderKeys.STATUS.getKey()).map(Object::toString));
     }
 
+    /**
+     * Retrieves the original topic from which the message was consumed.
+     *
+     * @param message message to inspect
+     * @return optional topic name
+     */
     public static Optional<String> getOriginalTopic(Message<?> message) {
         return getHeaderAsString(message.getHeaders(), KafkaHeaderKeys.ORIGINAL_TOPIC.getKey())
                 .or(() -> KafkaErrorMetadataContext.get(KafkaHeaderKeys.ORIGINAL_TOPIC.getKey()).map(Object::toString));
     }
 
+    /**
+     * Retrieves the object message identifier from the headers or context.
+     *
+     * @param message message to inspect
+     * @return optional identifier
+     */
     public static Optional<Long> getObjectMsgId(Message<?> message) {
         return getHeaderAsLong(message.getHeaders(), KafkaHeaderKeys.MESSAGE_ID.getKey())
                 .or(() -> KafkaErrorMetadataContext.get(KafkaHeaderKeys.MESSAGE_ID.getKey())
                         .map(val -> Long.parseLong(val.toString())));
     }
 
+    /**
+     * Reads a header value as a {@link String}.
+     *
+     * @param headers message headers
+     * @param key     header key
+     * @return optional string value
+     */
     public static Optional<String> getHeaderAsString(MessageHeaders headers, String key) {
         Object value = headers.get(key);
         return value != null ? Optional.of(value.toString()) : Optional.empty();
     }
 
+    /**
+     * Reads a header value as a {@link Long}.
+     *
+     * @param headers message headers
+     * @param key     header key
+     * @return optional long value
+     */
     public static Optional<Long> getHeaderAsLong(MessageHeaders headers, String key) {
         Object value = headers.get(key);
         return value != null ? Optional.of(Long.parseLong(value.toString())) : Optional.empty();

--- a/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/util/KafkaRetryHeaderUtils.java
+++ b/src/main/java/com/bnpparibas/bp2s/combo/comboservices/library/kafka/util/KafkaRetryHeaderUtils.java
@@ -15,18 +15,37 @@ import org.springframework.messaging.MessageHeaders;
  */
 public class KafkaRetryHeaderUtils {
 
+    /** Default value if no maxAttempts is configured. */
     private static final int DEFAULT_KAFKA_MAX_ATTEMPTS = 3;
+    /** Binding configuration used to look up retry settings. */
     private final BindingServiceProperties bindingServiceProperties;
 
+    /**
+     * Creates a new helper using the provided binding service properties.
+     *
+     * @param bindingServiceProperties Spring Cloud Stream binding properties
+     */
     public KafkaRetryHeaderUtils(BindingServiceProperties bindingServiceProperties) {
         this.bindingServiceProperties = bindingServiceProperties;
     }
 
+    /**
+     * Increments the delivery attempt header and returns the incremented value.
+     *
+     * @param message message to inspect
+     * @return new attempt number
+     */
     public int incrementAndGetRetryAttempt(Message<?> message) {
         int current = getCurrentAttempt(message);
         return current + 1;
     }
 
+    /**
+     * Retrieves the current attempt count from the message headers.
+     *
+     * @param message message to inspect
+     * @return attempt number or 0 if header missing
+     */
     public int getCurrentAttempt(Message<?> message) {
         MessageHeaders headers = message.getHeaders();
         Object header = headers.get(KafkaHeaderKeys.RETRY_ATTEMPT_HEADER.getKey());
@@ -39,6 +58,13 @@ public class KafkaRetryHeaderUtils {
         return 0;
     }
 
+    /**
+     * Resolves the Spring Cloud Stream binding name for the given message using
+     * the `kafka_receivedTopic` header.
+     *
+     * @param message message to inspect
+     * @return optional binding name
+     */
     public Optional<String> resolveBindingNameForMessage(Message<?> message) {
         Object topicHeader = message.getHeaders().get("kafka_receivedTopic");
         if (topicHeader == null)
@@ -57,11 +83,21 @@ public class KafkaRetryHeaderUtils {
         return Optional.empty();
     }
 
+    /**
+     * Determines the maximum allowed attempts for the message based on its
+     * binding configuration.
+     *
+     * @param message message to inspect
+     * @return configured max attempts or a default value
+     */
     public Integer resolveMaxAttemptsFromMessage(Message<?> message) {
         return resolveBindingNameForMessage(message).map(bindingName -> bindingServiceProperties.getConsumerProperties(bindingName).getMaxAttempts())
                 .orElse(DEFAULT_KAFKA_MAX_ATTEMPTS);
     }
 
+    /**
+     * Returns the binding name used by the library to publish DLQ messages.
+     */
     public String resolveDlqTopicBindingName() {
         return KafkaCoreAutoConfiguration.GLOBAL_DLQ_OUT;
     }


### PR DESCRIPTION
## Summary
- document library behavior in README and AsciiDoc files
- add UML diagrams for retry flow and metadata context
- clarify integration details and configuration
- provide comprehensive Javadoc across library classes

## Testing
- `mvn -q -e test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aec58d6fc832abe0b595df3b5a1ef